### PR TITLE
VCST-5163: Stable 15 — AzureAD (platform 3.1039.0)

### DIFF
--- a/src/VirtoCommerce.AzureAD.Core/VirtoCommerce.AzureAD.Core.csproj
+++ b/src/VirtoCommerce.AzureAD.Core/VirtoCommerce.AzureAD.Core.csproj
@@ -7,6 +7,6 @@
     <SonarQubeTestProject>false</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1002.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1039.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.AzureAD.Data/VirtoCommerce.AzureAD.Data.csproj
+++ b/src/VirtoCommerce.AzureAD.Data/VirtoCommerce.AzureAD.Data.csproj
@@ -11,6 +11,6 @@
   </ItemGroup>
   <ItemGroup>
     
-    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1002.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1039.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.AzureAD.Web/module.manifest
+++ b/src/VirtoCommerce.AzureAD.Web/module.manifest
@@ -4,7 +4,7 @@
   <version>3.1002.0</version>
   <version-tag />
 
-  <platformVersion>3.1002.0</platformVersion>
+  <platformVersion>3.1039.0</platformVersion>
   <dependencies />
 
   <title>Azure Active Directory Single Sign-On</title>


### PR DESCRIPTION
Part of **Stable 15** (Wave 1). Builds against the published platform [3.1039.0](https://github.com/VirtoCommerce/vc-platform/releases/tag/3.1039.0) from nuget.org.

- Platform -> **3.1039.0**; module version -> **3.1002.0**.
- `vc-build Compress` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only alignment against published platform packages; no changes to authentication or module behavior in this PR.
> 
> **Overview**
> **Stable 15 (Wave 1)** dependency alignment: the Azure AD module now targets **Virto Commerce platform 3.1039.0** instead of 3.1002.0.
> 
> `VirtoCommerce.Platform.Core` and `VirtoCommerce.Platform.Security` NuGet references are bumped to **3.1039.0**, and `module.manifest` **`platformVersion`** is updated to match. There are **no application or SSO logic changes** in this diff—only build/runtime platform pinning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dea48582e7a79bd3db66f4197f08c1a02be438d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5163
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.AzureAD_3.1002.0-pr-11-dea4.zip